### PR TITLE
Fix Import Errors and Install Missing Dependencies

### DIFF
--- a/backend/apps/accounts/apps.py
+++ b/backend/apps/accounts/apps.py
@@ -1,6 +1,8 @@
 from django.apps import AppConfig
 
+from apps import accounts
+
 
 class AccountsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'accounts'
+    name = 'apps.accounts'

--- a/backend/apps/companies/apps.py
+++ b/backend/apps/companies/apps.py
@@ -1,6 +1,8 @@
 from django.apps import AppConfig
 
+from apps import companies
+
 
 class CompaniesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'companies'
+    name = 'apps.companies'

--- a/backend/apps/departments/apps.py
+++ b/backend/apps/departments/apps.py
@@ -1,6 +1,8 @@
 from django.apps import AppConfig
 
+from apps import departments
+
 
 class DepartmentsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'departments'
+    name = 'apps.departments'

--- a/backend/apps/employees/apps.py
+++ b/backend/apps/employees/apps.py
@@ -1,6 +1,8 @@
 from django.apps import AppConfig
 
+from apps import employees
+
 
 class EmployeesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'employees'
+    name = 'apps.employees'


### PR DESCRIPTION
- Resolved ModuleNotFoundError: No module named 'pkg_resources' by upgrading setuptools.
- Installed missing dependencies: djangorestframework-simplejwt for auth, coreapi for api documetation, coreschema, jinja2, and MarkupSafe.