### PR TITLE
feat : Implements CompanySerializer with Calculated Properties

### DIFF
--- a/backend/apps/companies/serializers.py
+++ b/backend/apps/companies/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+from .models import Company
+
+class CompanySerializer(serializers.ModelSerializer):
+    number_of_departments = serializers.IntegerField(read_only=True)
+    number_of_employees = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Company
+        fields = ['id', 'name', 'number_of_departments', 'number_of_employees','created_at','updated_at']
+        read_only_fields = ['created_at', 'updated_at']


### PR DESCRIPTION
- Created `CompanySerializer` to serialize `Company` model instances.
- Defined fields to be serialized: `id`, `name`, `number_of_departments`, `number_of_employees`, `created_at`, and `updated_at`.
- Marked `created_at` and `updated_at` as read-only fields to prevent modification.- Created `CompanySerializer` to serialize `Company` model instances.
- Included calculated properties `number_of_departments` and `number_of_employees` as read-only fields.
- Defined fields to be serialized: `id`, `name`, `number_of_departments`, `number_of_employees`, `created_at`, and `updated_at`.